### PR TITLE
Feat/2 us discount create

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,7 @@
 class ApplicationController < ActionController::Base
+  private
+
+  def error_message(errors)
+    errors.full_messages.join(', ')
+  end
 end

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -14,8 +14,13 @@ class BulkDiscountsController < ApplicationController
   end
 
   def create
-    BulkDiscount.create!(bulk_discount_params)
-    redirect_to merchant_bulk_discounts_path(@merchant)
+    new_discount = BulkDiscount.new(bulk_discount_params)
+    if new_discount.save
+      redirect_to merchant_bulk_discounts_path(@merchant)
+    else
+      flash.notice = "All fields must be completed, get your act together."
+      redirect_to new_merchant_bulk_discount_path(@merchant)
+    end
   end
 
   private

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -6,6 +6,10 @@ class BulkDiscountsController < ApplicationController
   end
 
   def show
+
+  end
+
+  def new
     
   end
 

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -1,5 +1,5 @@
 class BulkDiscountsController < ApplicationController
-  before_action :find_merchant, only: [:index]
+  before_action :find_merchant, only: [:index, :new, :create]
 
   def index
     @bulk_discounts = @merchant.bulk_discounts
@@ -10,10 +10,19 @@ class BulkDiscountsController < ApplicationController
   end
 
   def new
-    
+
+  end
+
+  def create
+    BulkDiscount.create!(bulk_discount_params)
+    redirect_to merchant_bulk_discounts_path(@merchant)
   end
 
   private
+  def bulk_discount_params
+    params.permit(:percentage, :quantity_threshold, :merchant_id)
+  end
+
   def find_merchant
     @merchant = Merchant.find(params[:merchant_id])
   end

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -18,7 +18,7 @@ class BulkDiscountsController < ApplicationController
     if new_discount.save
       redirect_to merchant_bulk_discounts_path(@merchant)
     else
-      flash.notice = "All fields must be completed, get your act together."
+      flash[:alert] = error_message(new_discount.errors)
       redirect_to new_merchant_bulk_discount_path(@merchant)
     end
   end

--- a/app/models/bulk_discount.rb
+++ b/app/models/bulk_discount.rb
@@ -1,6 +1,8 @@
 class BulkDiscount < ApplicationRecord
   validates_presence_of :percentage
   validates_presence_of :quantity_threshold
+  validates :percentage, numericality: { greater_than_or_equal_to: 0, only_integer: true }
+  validates :quantity_threshold, numericality: { greater_than_or_equal_to: 0, only_integer: true }
   belongs_to :merchant
   has_many :invoice_items, through: :merchant
 end

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -1,5 +1,7 @@
 <%= render partial: "shared/nav" %>
 
+<p><%= link_to "Create New Discount", new_merchant_bulk_discount_path(@merchant) %></p>
+
 <% @bulk_discounts.each do |discount| %>
   <div id=<%= "discount-#{discount.id}" %>>
     <%= link_to "#{discount.percentage}% off #{discount.quantity_threshold} items",

--- a/app/views/bulk_discounts/new.html.erb
+++ b/app/views/bulk_discounts/new.html.erb
@@ -1,0 +1,7 @@
+<%= form_with method: :post, url: merchant_bulk_discounts_path(@merchant), local: true do |f| %>
+  <%= f.label :percentage %>
+  <%= f.text_field :percentage %><br/><br/>
+  <%= f.label :quantity_threshold %>
+  <%= f.text_field :quantity_threshold %><br/><br/>
+  <%= f.submit 'Submit'%>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
   </head>
 
   <body>
+
     <div class="top-container">
       <h1>Little Esty Shop - Final</h1>
       <div class="container">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show]
+    resources :bulk_discounts, only: [:index, :show, :new]
   end
 
   namespace :admin do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show, :new]
+    resources :bulk_discounts, only: [:index, :show, :new, :create]
   end
 
   namespace :admin do

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -99,7 +99,7 @@ describe "bulk discounts index" do
   # Then I am redirected back to the bulk discount index
   # And I see my new bulk discount listed
   it 'There is a link to create a new discount, when clicked, directs to form page, fill in with good information and submit' do
-    expect(page).to have_link('Create Discount')
+    expect(page).to have_link('Create New Discount')
 
     click_link('Create New Discount')
 
@@ -112,5 +112,5 @@ describe "bulk discounts index" do
     expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
     expect(page).to have_content('30% off 20 items')
   end
-  
+
 end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -113,4 +113,13 @@ describe "bulk discounts index" do
     expect(page).to have_content('30% off 20 items')
   end
 
+  it 'Create new discount, missing information before submit' do
+    click_link('Create New Discount')    
+    fill_in 'Percentage', with: 30
+    click_button 'Submit'
+
+    expect(current_path).to eq(new_merchant_bulk_discount_path(@merchant1))
+    expect(page).to have_content('All fields must be completed, get your act together.')
+  end
+
 end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -117,9 +117,43 @@ describe "bulk discounts index" do
     click_link('Create New Discount')    
     fill_in 'Percentage', with: 30
     click_button 'Submit'
+    
+    expect(current_path).to eq(new_merchant_bulk_discount_path(@merchant1))
+    expect(page).to have_content("Quantity threshold can't be blank, Quantity threshold is not a number")
+  end
+
+  it 'Create new discount, sad path: non-numerical values' do
+    click_link('Create New Discount')    
+    fill_in 'Percentage', with: "30%"
+    fill_in 'Quantity threshold', with: "20a"
+
+    click_button 'Submit'
 
     expect(current_path).to eq(new_merchant_bulk_discount_path(@merchant1))
-    expect(page).to have_content('All fields must be completed, get your act together.')
+    expect(page).to have_content("Percentage is not a number, Quantity threshold is not a number")
+  end
+
+  it 'Create new discount, sad path: negative numbers' do
+    click_link('Create New Discount')    
+    fill_in 'Percentage', with: -30
+    fill_in 'Quantity threshold', with: -20
+
+    click_button 'Submit'
+
+    expect(current_path).to eq(new_merchant_bulk_discount_path(@merchant1))
+    expect(page).to have_content("Percentage must be greater than or equal to 0, Quantity threshold must be greater than or equal to 0")
+  end
+
+  # Percentage does not actually HAVE to be, just decided to make it a requirement for simplicity
+  it 'Create new discount, sad path: integers only' do
+    click_link('Create New Discount')    
+    fill_in 'Percentage', with: 30.5
+    fill_in 'Quantity threshold', with: 20.5
+
+    click_button 'Submit'
+
+    expect(current_path).to eq(new_merchant_bulk_discount_path(@merchant1))
+    expect(page).to have_content("Percentage must be an integer, Quantity threshold must be an integer")
   end
 
 end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -76,7 +76,7 @@ describe "bulk discounts index" do
     expect(page).to_not have_css("#discount-#{@discount_3.id}")
   end
 
-  it 'Each discount is a link to its show page, when clicked directs to proper location' do
+  it 'Each discount is a link to its show page, when clicked directs to proper show page' do
     within "#discount-#{@discount_1.id}" do
       expect(page).to have_link("10% off 5 items")
     end
@@ -89,4 +89,28 @@ describe "bulk discounts index" do
     expect(current_path).to eq("/merchants/#{@merchant1.id}/bulk_discounts/#{@discount_2.id}")
   end
 
+  # 2: Merchant Bulk Discount Create
+  # As a merchant
+  # When I visit my bulk discounts index
+  # Then I see a link to create a new discount
+  # When I click this link
+  # Then I am taken to a new page where I see a form to add a new bulk discount
+  # When I fill in the form with valid data
+  # Then I am redirected back to the bulk discount index
+  # And I see my new bulk discount listed
+  it 'There is a link to create a new discount, when clicked, directs to form page, fill in with good information and submit' do
+    expect(page).to have_link('Create Discount')
+
+    click_link('Create New Discount')
+
+    expect(current_path).to eq("/merchants/#{@merchant1.id}/bulk_discounts/new")
+    
+    fill_in 'Percentage', with: 30
+    fill_in 'Threshold', with: 20
+    click_button 'Submit'
+
+    expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
+    expect(page).to have_content('30% off 20 items')
+  end
+  
 end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -106,9 +106,9 @@ describe "bulk discounts index" do
     expect(current_path).to eq("/merchants/#{@merchant1.id}/bulk_discounts/new")
     
     fill_in 'Percentage', with: 30
-    fill_in 'Threshold', with: 20
+    fill_in 'Quantity threshold', with: 20
     click_button 'Submit'
-
+    
     expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
     expect(page).to have_content('30% off 20 items')
   end

--- a/spec/models/bulk_discount_spec.rb
+++ b/spec/models/bulk_discount_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe BulkDiscount, type: :model do
   describe "validations" do
     it { should validate_presence_of :percentage}
     it { should validate_presence_of :quantity_threshold }
+    it { should validate_numericality_of(:percentage).is_greater_than_or_equal_to(0).only_integer }
+    it { should validate_numericality_of(:quantity_threshold).is_greater_than_or_equal_to(0).only_integer }
   end
   describe "relationships" do
     it { should belong_to :merchant }


### PR DESCRIPTION
2: Merchant Bulk Discount Create

As a merchant
When I visit my bulk discounts index
Then I see a link to create a new discount
When I click this link
Then I am taken to a new page where I see a form to add a new bulk discount
When I fill in the form with valid data
Then I am redirected back to the bulk discount index
And I see my new bulk discount listed

Included sad paths for bulk discounts, only numbers, greater than 0, has to be an integer