### PR TITLE
Feat/3 discount delete

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -1,16 +1,15 @@
 class BulkDiscountsController < ApplicationController
-  before_action :find_merchant, only: [:index, :new, :create]
+  before_action :find_merchant, only: [:index, :new, :create, :destroy]
+  before_action :find_bulk_discount, only: [:destroy]
 
   def index
     @bulk_discounts = @merchant.bulk_discounts
   end
 
   def show
-
   end
 
   def new
-
   end
 
   def create
@@ -23,6 +22,11 @@ class BulkDiscountsController < ApplicationController
     end
   end
 
+  def destroy
+    @bulk_discount.destroy
+    redirect_to merchant_bulk_discounts_path(@merchant)
+  end
+
   private
   def bulk_discount_params
     params.permit(:percentage, :quantity_threshold, :merchant_id)
@@ -30,5 +34,9 @@ class BulkDiscountsController < ApplicationController
 
   def find_merchant
     @merchant = Merchant.find(params[:merchant_id])
+  end
+
+  def find_bulk_discount
+    @bulk_discount = BulkDiscount.find(params[:id])
   end
 end

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -7,5 +7,6 @@
     <%= link_to "#{discount.percentage}% off #{discount.quantity_threshold} items",
                 merchant_bulk_discount_path(@merchant.id, discount.id) 
     %>
+    <%= button_to "Delete", merchant_bulk_discount_path(@merchant, discount), method: :delete %>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show, :new, :create]
+    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy]
   end
 
   namespace :admin do

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -113,7 +113,7 @@ describe "bulk discounts index" do
     expect(page).to have_content('30% off 20 items')
   end
 
-  it 'Create new discount, missing information before submit' do
+  it 'Create new discount, sad path: missing information' do
     click_link('Create New Discount')    
     fill_in 'Percentage', with: 30
     click_button 'Submit'
@@ -156,4 +156,25 @@ describe "bulk discounts index" do
     expect(page).to have_content("Percentage must be an integer, Quantity threshold must be an integer")
   end
 
+  # 3: Merchant Bulk Discount Delete
+  # As a merchant
+  # When I visit my bulk discounts index
+  # Then next to each bulk discount I see a button to delete it
+  # When I click this button
+  # Then I am redirected back to the bulk discounts index page
+  # And I no longer see the discount listed
+  it 'There is delete button next to each discount, click, redirects back, discount is gone' do
+    within "#discount-#{@discount_1.id}" do
+      expect(page).to have_button('Delete')
+    end
+
+    within "#discount-#{@discount_2.id}" do
+      expect(page).to have_button('Delete')
+      click_button('Delete')
+    end
+
+    expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
+    expect(page).to_not have_css("#discount-#{@discount_2.id}")
+    expect(page).to_not have_content("20% off 10 items")
+  end
 end


### PR DESCRIPTION
3: Merchant Bulk Discount Delete
As a merchant
When I visit my bulk discounts index
Then next to each bulk discount I see a button to delete it
When I click this button
Then I am redirected back to the bulk discounts index page
And I no longer see the discount listed

If time later, maybe add flash message for successful delete