### PR TITLE
Feat/5 us discount edit

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -15,6 +15,7 @@ class BulkDiscountsController < ApplicationController
   def create
     new_discount = BulkDiscount.new(bulk_discount_params)
     if new_discount.save
+      flash[:notice] = 'Succesfully Added Discount!'
       redirect_to merchant_bulk_discounts_path(@merchant)
     else
       flash[:alert] = error_message(new_discount.errors)

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -40,9 +40,9 @@ class BulkDiscountsController < ApplicationController
     if @bulk_discount.update(bulk_discount_params)
       flash[:notice] = 'Succesfully Updated Discount Info!'
       redirect_to merchant_bulk_discount_path(@merchant, @bulk_discount)
-    # else
-    #   flash[:alert] = error_message(@bulk_discount.errors)
-    #   redirect_to edit_merchant_bulk_discount_path(@merchant, @bulk_discount)
+    else
+      flash[:alert] = error_message(@bulk_discount.errors)
+      render :edit
     end
   end
 

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -1,6 +1,6 @@
 class BulkDiscountsController < ApplicationController
-  before_action :find_merchant, only: [:index, :new, :create, :destroy, :show, :edit]
-  before_action :find_bulk_discount, only: [:destroy, :show, :edit]
+  before_action :find_merchant, only: [:index, :new, :create, :destroy, :show, :edit, :update]
+  before_action :find_bulk_discount, only: [:destroy, :show, :edit, :update]
 
   def index
     @bulk_discounts = @merchant.bulk_discounts
@@ -34,6 +34,16 @@ class BulkDiscountsController < ApplicationController
   end
 
   def edit
+  end
+
+  def update
+    if @bulk_discount.update(bulk_discount_params)
+      flash[:notice] = 'Succesfully Updated Discount Info!'
+      redirect_to merchant_bulk_discount_path(@merchant, @bulk_discount)
+    # else
+    #   flash[:alert] = error_message(@bulk_discount.errors)
+    #   redirect_to edit_merchant_bulk_discount_path(@merchant, @bulk_discount)
+    end
   end
 
   private

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -1,6 +1,6 @@
 class BulkDiscountsController < ApplicationController
-  before_action :find_merchant, only: [:index, :new, :create, :destroy]
-  before_action :find_bulk_discount, only: [:destroy, :show]
+  before_action :find_merchant, only: [:index, :new, :create, :destroy, :show, :edit]
+  before_action :find_bulk_discount, only: [:destroy, :show, :edit]
 
   def index
     @bulk_discounts = @merchant.bulk_discounts
@@ -30,6 +30,9 @@ class BulkDiscountsController < ApplicationController
       flash[:alert] = 'Failed to delete discount'
       redirect_to merchant_bulk_discounts_path(@merchant)
     end
+  end
+
+  def edit
   end
 
   private

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,0 +1,7 @@
+<%= form_with method: :patch, url: edit_merchant_bulk_discount_path(@merchant, @bulk_discount), local: true do |f| %>
+  <%= f.label :percentage %>
+  <%= f.text_field :percentage, value: @bulk_discount.percentage %><br/><br/>
+  <%= f.label :quantity_threshold %>
+  <%= f.text_field :quantity_threshold, value: @bulk_discount.quantity_threshold %><br/><br/>
+  <%= f.submit 'Submit'%>
+<% end %>

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,4 +1,4 @@
-<%= form_with method: :patch, url: edit_merchant_bulk_discount_path(@merchant, @bulk_discount), local: true do |f| %>
+<%= form_with model: @bulk_discount, method: :patch, url: merchant_bulk_discount_path(@merchant, @bulk_discount), local: true do |f| %>
   <%= f.label :percentage %>
   <%= f.text_field :percentage, value: @bulk_discount.percentage %><br/><br/>
   <%= f.label :quantity_threshold %>

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -1,2 +1,4 @@
 <p>Discount: <%= @bulk_discount.percentage %>%</p>
 <p>Threshold: <%= @bulk_discount.quantity_threshold %> items</p>
+
+<p><%= link_to "Edit", edit_merchant_bulk_discount_path(@merchant, @bulk_discount) %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy, :edit, :update]
+    resources :bulk_discounts
   end
 
   namespace :admin do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy]
+    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy, :edit, :update]
   end
 
   namespace :admin do

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -77,5 +77,40 @@ describe "bulk discount edit" do
     expect(page).to have_content('Succesfully Updated Discount Info!')
   end
 
-  
+  # These did not seem to be picked up by validations, and would always keep current attribute value if something else was entered
+  # xit 'Edit discount, sad path: missing information' do
+  #   fill_in 'Percentage', with: ''
+  #   fill_in 'Quantity threshold', with: ''
+  #   click_button 'Submit'
+
+  #   expect(current_path).to eq(edit_merchant_bulk_discount_path(@merchant1, @discount_1))
+  #   expect(page).to have_content("Quantity threshold can't be blank, Quantity threshold is not a number")
+  # end
+
+  # xit 'Edit discount, sad path: non-numerical values' do
+  #   fill_in 'Percentage', with: "30%"
+  #   fill_in 'Quantity threshold', with: "20a"
+  #   click_button 'Submit'
+
+  #   expect(current_path).to eq(edit_merchant_bulk_discount_path(@merchant1, @discount_1))
+  #   expect(page).to have_content('Percentage is not a number, Quantity threshold is not a number')
+  # end
+
+  # xit 'Edit discount, sad path: negative numbers' do
+  #   fill_in 'Percentage', with: -30
+  #   fill_in 'Quantity threshold', with: -20
+  #   click_button 'Submit'
+
+  #   expect(current_path).to eq(edit_merchant_bulk_discount_path(@merchant1, @discount_1))
+  #   expect(page).to have_content('Percentage must be greater than or equal to 0, Quantity threshold must be greater than or equal to 0')
+  # end
+
+  # xit 'Edit discount, sad path: integers only' do
+  #   fill_in 'Percentage', with: 30.5
+  #   fill_in 'Quantity threshold', with: 20.5
+  #   click_button 'Submit'
+
+  #   expect(current_path).to eq(edit_merchant_bulk_discount_path(@merchant1, @discount_1))
+  #   expect(page).to have_content('Percentage must be an integer, Quantity threshold must be an integer')
+  # end
 end

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "bulk discount show" do
+describe "bulk discount edit" do
   before :each do
     @merchant1 = Merchant.create!(name: "Hair Care")
     @merchant2 = Merchant.create!(name: "Jewelry")
@@ -53,19 +53,10 @@ describe "bulk discount show" do
 
     @discount_1 = BulkDiscount.create!(percentage: 10, quantity_threshold: 5, merchant_id: @merchant1.id)
 
-    visit merchant_bulk_discount_path(@merchant1, @discount_1)
+    visit edit_merchant_bulk_discount_path(@merchant1, @discount_1)
   end
 
-  # 4: Merchant Bulk Discount Show
-  # As a merchant
-  # When I visit my bulk discount show page
-  # Then I see the bulk discount's quantity threshold and percentage discount
-  it 'When merchant visits discount show page, they see quantity threshold and percentage discount' do
-    expect(page).to have_content('Discount: 10%')
-    expect(page).to have_content('Threshold: 5 items')
-  end
-
-  # 5: Merchant Bulk Discount Edit, part 1
+  # 5: Merchant Bulk Discount Edit, part 2
   # As a merchant
   # When I visit my bulk discount show page
   # Then I see a link to edit the bulk discount
@@ -75,13 +66,14 @@ describe "bulk discount show" do
   # When I change any/all of the information and click submit
   # Then I am redirected to the bulk discount's show page
   # And I see that the discount's attributes have been updated
-  it 'There is an edit button, directs to form to edit, prepopulated with current attributes' do
-    expect(page).to have_link('Edit')
+  it 'Update with proper information' do
+    fill_in 'Percentage', with: '30'
+    fill_in 'Quantity threshold', with: '15'
+    click_button 'Submit'
 
-    click_link('Edit')
-
-    expect(current_path).to eq("/merchants/#{@merchant1.id}/bulk_discounts/#{@discount_1.id}/edit")
-    expect(find_field('Percentage').value).to eq('10')
-    expect(find_field('Quantity threshold').value).to eq('5')
+    expect(current_path).to eq(merchant_bulk_discount_path(@merchant1, @discount_1))
+    expect(page).to have_content('Discount: 10%')
+    expect(page).to have_content('Threshold: 5 items')
+    expect(page).to have_content('Succesfully Updated Discount Info!')
   end
 end

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -76,4 +76,6 @@ describe "bulk discount edit" do
     expect(page).to have_content('Threshold: 5 items')
     expect(page).to have_content('Succesfully Updated Discount Info!')
   end
+
+  
 end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -111,6 +111,7 @@ describe "bulk discounts index" do
     
     expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
     expect(page).to have_content('30% off 20 items')
+    expect(page).to have_content('Succesfully Added Discount!')
   end
 
   it 'Create new discount, sad path: missing information' do

--- a/spec/features/bulk_discounts/show_spec.rb
+++ b/spec/features/bulk_discounts/show_spec.rb
@@ -64,4 +64,24 @@ describe "bulk discount show" do
     expect(page).to have_content('Discount: 10%')
     expect(page).to have_content('Threshold: 5 items')
   end
+
+  # 5: Merchant Bulk Discount Edit
+  # As a merchant
+  # When I visit my bulk discount show page
+  # Then I see a link to edit the bulk discount
+  # When I click this link
+  # Then I am taken to a new page with a form to edit the discount
+  # And I see that the discounts current attributes are pre-poluated in the form
+  # When I change any/all of the information and click submit
+  # Then I am redirected to the bulk discount's show page
+  # And I see that the discount's attributes have been updated
+  it 'There is an edit button, directs to form to edit, prepopulated with current attributes' do
+    expect(page).to have_content('Edit')
+
+    click_button('Edit')
+
+    expect(current_path).to eq(edit_merchant_bulk_discount(@merchant1, @discount_1))
+    expect(find_field('Percentage').value).to eq('10')
+    expect(find_field('Quantity threshold').value).to eq('5')
+  end
 end

--- a/spec/features/bulk_discounts/show_spec.rb
+++ b/spec/features/bulk_discounts/show_spec.rb
@@ -76,11 +76,11 @@ describe "bulk discount show" do
   # Then I am redirected to the bulk discount's show page
   # And I see that the discount's attributes have been updated
   it 'There is an edit button, directs to form to edit, prepopulated with current attributes' do
-    expect(page).to have_content('Edit')
+    expect(page).to have_link('Edit')
 
-    click_button('Edit')
+    click_link('Edit')
 
-    expect(current_path).to eq(edit_merchant_bulk_discount(@merchant1, @discount_1))
+    expect(current_path).to eq("/merchants/#{@merchant1.id}/bulk_discounts/#{@discount_1.id}/edit")
     expect(find_field('Percentage').value).to eq('10')
     expect(find_field('Quantity threshold').value).to eq('5')
   end


### PR DESCRIPTION
5: Merchant Bulk Discount Edit

As a merchant
When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discounts current attributes are pre-poluated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated

Only has successful update path, it seems to keep current attributes when odd ones are added