### PR TITLE
Feat/6 merchant invoice show total discounted revenue

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -16,6 +16,7 @@ class Invoice < ApplicationRecord
   end
 
   def discount_revenue
+    require 'pry'; binding.pry
     InvoiceItems.joins()
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -7,10 +7,15 @@ class Invoice < ApplicationRecord
   has_many :invoice_items
   has_many :items, through: :invoice_items
   has_many :merchants, through: :items
+  has_many :bulk_discounts, through: :items
 
   enum status: [:cancelled, :in_progress, :completed]
 
   def total_revenue
     invoice_items.sum("unit_price * quantity")
+  end
+
+  def discount_revenue
+    InvoiceItems.joins()
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -7,7 +7,8 @@ class Invoice < ApplicationRecord
   has_many :invoice_items
   has_many :items, through: :invoice_items
   has_many :merchants, through: :items
-  has_many :bulk_discounts, through: :items
+  # Check if this is even required
+  # has_many :bulk_discounts, through: :items
 
   enum status: [:cancelled, :in_progress, :completed]
 
@@ -16,7 +17,19 @@ class Invoice < ApplicationRecord
   end
 
   def discount_revenue
-    require 'pry'; binding.pry
-    InvoiceItems.joins()
+    discounted = InvoiceItem.joins(merchant: :bulk_discounts)
+                            .where("invoice_items.invoice_id = ?", self.id)
+                            .where("invoice_items.quantity >= bulk_discounts.quantity_threshold")
+                            .group("invoice_items.id")
+                            .select("invoice_items.*, (1 - MAX(bulk_discounts.percentage) / 100.0) * invoice_items.quantity * invoice_items.unit_price AS item_revenue")
+        
+    discounted_total = discounted.sum(&:item_revenue) # Couldnt use two aggregates, so a little Ruby here, pluck(:item_revenue) did not work
+
+    non_discounted_total = InvoiceItem.where("invoice_items.invoice_id = ?", self.id)
+                                      .where.not(id: discounted.pluck(:id))
+                                      .sum("invoice_items.quantity * invoice_items.unit_price")
+
+    discount_revenue = discounted_total + non_discounted_total
   end
+
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -7,6 +7,7 @@ class InvoiceItem < ApplicationRecord
 
   belongs_to :invoice
   belongs_to :item
+  has_one :merchant, through: :item
 
   enum status: [:pending, :packaged, :shipped]
 

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -11,7 +11,7 @@
   <br>
 
   <p> Created on: <%= @invoice.created_at.strftime("%A, %B %-d, %Y") %></p>
-  <p>Total Revenue: <%= @invoice.total_revenue %></p>
+  <p>Total Revenue: $<%= @invoice.total_revenue %></p>
 
 
   <h4>Customer:</h4>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -12,6 +12,7 @@
 
   <p> Created on: <%= @invoice.created_at.strftime("%A, %B %-d, %Y") %></p>
   <p>Total Revenue: $<%= @invoice.total_revenue %></p>
+  <p>Discount Revenue: $<%= @invoice.discount_revenue %></p>
 
 
   <h4>Customer:</h4>

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe "invoices show" do
 
       @transaction1 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_1.id)
 
-      @discount_1 = Discount.create!(percentage: 50, quantity_threshold: 10, merchant_id: @merchant1.id)
+      @discount_1 = BulkDiscount.create!(percentage: 50, quantity_threshold: 10, merchant_id: @merchant1.id)
       visit merchant_invoice_path(@merchant1, @invoice_1)
     end
 

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -136,8 +136,9 @@ RSpec.describe "invoices show" do
       # Then I see the total revenue for my merchant from this invoice (not including discounts)
       # And I see the total discounted revenue for my merchant from this invoice which includes bulk discounts in the calculation
     it 'Shows total revenue and discount revenue for invoice' do
+      save_and_open_page
       expect(page).to have_content('Total Revenue: $162.0')
-      expect(page).to have_content('Discount Revenue: $144.0')
+      expect(page).to have_content('Discount Revenue: $126.0')
     end
   end
 

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -1,102 +1,143 @@
 require "rails_helper"
 
 RSpec.describe "invoices show" do
-  before :each do
-    @merchant1 = Merchant.create!(name: "Hair Care")
-    @merchant2 = Merchant.create!(name: "Jewelry")
+  describe 'Project part 1' do
+    before :each do
+      @merchant1 = Merchant.create!(name: "Hair Care")
+      @merchant2 = Merchant.create!(name: "Jewelry")
 
-    @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
-    @item_2 = Item.create!(name: "Conditioner", description: "This makes your hair shiny", unit_price: 8, merchant_id: @merchant1.id)
-    @item_3 = Item.create!(name: "Brush", description: "This takes out tangles", unit_price: 5, merchant_id: @merchant1.id)
-    @item_4 = Item.create!(name: "Hair tie", description: "This holds up your hair", unit_price: 1, merchant_id: @merchant1.id)
-    @item_7 = Item.create!(name: "Scrunchie", description: "This holds up your hair but is bigger", unit_price: 3, merchant_id: @merchant1.id)
-    @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
+      @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
+      @item_2 = Item.create!(name: "Conditioner", description: "This makes your hair shiny", unit_price: 8, merchant_id: @merchant1.id)
+      @item_3 = Item.create!(name: "Brush", description: "This takes out tangles", unit_price: 5, merchant_id: @merchant1.id)
+      @item_4 = Item.create!(name: "Hair tie", description: "This holds up your hair", unit_price: 1, merchant_id: @merchant1.id)
+      @item_7 = Item.create!(name: "Scrunchie", description: "This holds up your hair but is bigger", unit_price: 3, merchant_id: @merchant1.id)
+      @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
 
-    @item_5 = Item.create!(name: "Bracelet", description: "Wrist bling", unit_price: 200, merchant_id: @merchant2.id)
-    @item_6 = Item.create!(name: "Necklace", description: "Neck bling", unit_price: 300, merchant_id: @merchant2.id)
+      @item_5 = Item.create!(name: "Bracelet", description: "Wrist bling", unit_price: 200, merchant_id: @merchant2.id)
+      @item_6 = Item.create!(name: "Necklace", description: "Neck bling", unit_price: 300, merchant_id: @merchant2.id)
 
-    @customer_1 = Customer.create!(first_name: "Joey", last_name: "Smith")
-    @customer_2 = Customer.create!(first_name: "Cecilia", last_name: "Jones")
-    @customer_3 = Customer.create!(first_name: "Mariah", last_name: "Carrey")
-    @customer_4 = Customer.create!(first_name: "Leigh Ann", last_name: "Bron")
-    @customer_5 = Customer.create!(first_name: "Sylvester", last_name: "Nader")
-    @customer_6 = Customer.create!(first_name: "Herber", last_name: "Kuhn")
+      @customer_1 = Customer.create!(first_name: "Joey", last_name: "Smith")
+      @customer_2 = Customer.create!(first_name: "Cecilia", last_name: "Jones")
+      @customer_3 = Customer.create!(first_name: "Mariah", last_name: "Carrey")
+      @customer_4 = Customer.create!(first_name: "Leigh Ann", last_name: "Bron")
+      @customer_5 = Customer.create!(first_name: "Sylvester", last_name: "Nader")
+      @customer_6 = Customer.create!(first_name: "Herber", last_name: "Kuhn")
 
-    @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-27 14:54:09")
-    @invoice_2 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-28 14:54:09")
-    @invoice_3 = Invoice.create!(customer_id: @customer_2.id, status: 2)
-    @invoice_4 = Invoice.create!(customer_id: @customer_3.id, status: 2)
-    @invoice_5 = Invoice.create!(customer_id: @customer_4.id, status: 2)
-    @invoice_6 = Invoice.create!(customer_id: @customer_5.id, status: 2)
-    @invoice_7 = Invoice.create!(customer_id: @customer_6.id, status: 2)
+      @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-27 14:54:09")
+      @invoice_2 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-28 14:54:09")
+      @invoice_3 = Invoice.create!(customer_id: @customer_2.id, status: 2)
+      @invoice_4 = Invoice.create!(customer_id: @customer_3.id, status: 2)
+      @invoice_5 = Invoice.create!(customer_id: @customer_4.id, status: 2)
+      @invoice_6 = Invoice.create!(customer_id: @customer_5.id, status: 2)
+      @invoice_7 = Invoice.create!(customer_id: @customer_6.id, status: 2)
 
-    @invoice_8 = Invoice.create!(customer_id: @customer_6.id, status: 1)
+      @invoice_8 = Invoice.create!(customer_id: @customer_6.id, status: 1)
 
-    @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
-    @ii_2 = InvoiceItem.create!(invoice_id: @invoice_2.id, item_id: @item_1.id, quantity: 1, unit_price: 10, status: 2)
-    @ii_3 = InvoiceItem.create!(invoice_id: @invoice_3.id, item_id: @item_2.id, quantity: 2, unit_price: 8, status: 2)
-    @ii_4 = InvoiceItem.create!(invoice_id: @invoice_4.id, item_id: @item_3.id, quantity: 3, unit_price: 5, status: 1)
-    @ii_6 = InvoiceItem.create!(invoice_id: @invoice_5.id, item_id: @item_4.id, quantity: 1, unit_price: 1, status: 1)
-    @ii_7 = InvoiceItem.create!(invoice_id: @invoice_6.id, item_id: @item_7.id, quantity: 1, unit_price: 3, status: 1)
-    @ii_8 = InvoiceItem.create!(invoice_id: @invoice_7.id, item_id: @item_8.id, quantity: 1, unit_price: 5, status: 1)
-    @ii_9 = InvoiceItem.create!(invoice_id: @invoice_7.id, item_id: @item_4.id, quantity: 1, unit_price: 1, status: 1)
-    @ii_10 = InvoiceItem.create!(invoice_id: @invoice_8.id, item_id: @item_5.id, quantity: 1, unit_price: 1, status: 1)
-    @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 12, unit_price: 6, status: 1)
+      @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
+      @ii_2 = InvoiceItem.create!(invoice_id: @invoice_2.id, item_id: @item_1.id, quantity: 1, unit_price: 10, status: 2)
+      @ii_3 = InvoiceItem.create!(invoice_id: @invoice_3.id, item_id: @item_2.id, quantity: 2, unit_price: 8, status: 2)
+      @ii_4 = InvoiceItem.create!(invoice_id: @invoice_4.id, item_id: @item_3.id, quantity: 3, unit_price: 5, status: 1)
+      @ii_6 = InvoiceItem.create!(invoice_id: @invoice_5.id, item_id: @item_4.id, quantity: 1, unit_price: 1, status: 1)
+      @ii_7 = InvoiceItem.create!(invoice_id: @invoice_6.id, item_id: @item_7.id, quantity: 1, unit_price: 3, status: 1)
+      @ii_8 = InvoiceItem.create!(invoice_id: @invoice_7.id, item_id: @item_8.id, quantity: 1, unit_price: 5, status: 1)
+      @ii_9 = InvoiceItem.create!(invoice_id: @invoice_7.id, item_id: @item_4.id, quantity: 1, unit_price: 1, status: 1)
+      @ii_10 = InvoiceItem.create!(invoice_id: @invoice_8.id, item_id: @item_5.id, quantity: 1, unit_price: 1, status: 1)
+      @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 12, unit_price: 6, status: 1)
 
-    @transaction1 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_1.id)
-    @transaction2 = Transaction.create!(credit_card_number: 230948, result: 1, invoice_id: @invoice_2.id)
-    @transaction3 = Transaction.create!(credit_card_number: 234092, result: 1, invoice_id: @invoice_3.id)
-    @transaction4 = Transaction.create!(credit_card_number: 230429, result: 1, invoice_id: @invoice_4.id)
-    @transaction5 = Transaction.create!(credit_card_number: 102938, result: 1, invoice_id: @invoice_5.id)
-    @transaction6 = Transaction.create!(credit_card_number: 879799, result: 0, invoice_id: @invoice_6.id)
-    @transaction7 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_7.id)
-    @transaction8 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_8.id)
-  end
-
-  it "shows the invoice information" do
-    visit merchant_invoice_path(@merchant1, @invoice_1)
-
-    expect(page).to have_content(@invoice_1.id)
-    expect(page).to have_content(@invoice_1.status)
-    expect(page).to have_content(@invoice_1.created_at.strftime("%A, %B %-d, %Y"))
-  end
-
-  it "shows the customer information" do
-    visit merchant_invoice_path(@merchant1, @invoice_1)
-
-    expect(page).to have_content(@customer_1.first_name)
-    expect(page).to have_content(@customer_1.last_name)
-    expect(page).to_not have_content(@customer_2.last_name)
-  end
-
-  it "shows the item information" do
-    visit merchant_invoice_path(@merchant1, @invoice_1)
-
-    expect(page).to have_content(@item_1.name)
-    expect(page).to have_content(@ii_1.quantity)
-    expect(page).to have_content(@ii_1.unit_price)
-    expect(page).to_not have_content(@ii_4.unit_price)
-
-  end
-
-  it "shows the total revenue for this invoice" do
-    visit merchant_invoice_path(@merchant1, @invoice_1)
-
-    expect(page).to have_content(@invoice_1.total_revenue)
-  end
-
-  it "shows a select field to update the invoice status" do
-    visit merchant_invoice_path(@merchant1, @invoice_1)
-
-    within("#the-status-#{@ii_1.id}") do
-      page.select("cancelled")
-      click_button "Update Invoice"
-
-      expect(page).to have_content("cancelled")
+      @transaction1 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_1.id)
+      @transaction2 = Transaction.create!(credit_card_number: 230948, result: 1, invoice_id: @invoice_2.id)
+      @transaction3 = Transaction.create!(credit_card_number: 234092, result: 1, invoice_id: @invoice_3.id)
+      @transaction4 = Transaction.create!(credit_card_number: 230429, result: 1, invoice_id: @invoice_4.id)
+      @transaction5 = Transaction.create!(credit_card_number: 102938, result: 1, invoice_id: @invoice_5.id)
+      @transaction6 = Transaction.create!(credit_card_number: 879799, result: 0, invoice_id: @invoice_6.id)
+      @transaction7 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_7.id)
+      @transaction8 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_8.id)
     end
 
-    within("#current-invoice-status") do
-      expect(page).to_not have_content("in progress")
+    it "shows the invoice information" do
+      visit merchant_invoice_path(@merchant1, @invoice_1)
+
+      expect(page).to have_content(@invoice_1.id)
+      expect(page).to have_content(@invoice_1.status)
+      expect(page).to have_content(@invoice_1.created_at.strftime("%A, %B %-d, %Y"))
+    end
+
+    it "shows the customer information" do
+      visit merchant_invoice_path(@merchant1, @invoice_1)
+
+      expect(page).to have_content(@customer_1.first_name)
+      expect(page).to have_content(@customer_1.last_name)
+      expect(page).to_not have_content(@customer_2.last_name)
+    end
+
+    it "shows the item information" do
+      visit merchant_invoice_path(@merchant1, @invoice_1)
+
+      expect(page).to have_content(@item_1.name)
+      expect(page).to have_content(@ii_1.quantity)
+      expect(page).to have_content(@ii_1.unit_price)
+      expect(page).to_not have_content(@ii_4.unit_price)
+
+    end
+
+    it "shows the total revenue for this invoice" do
+      visit merchant_invoice_path(@merchant1, @invoice_1)
+
+      expect(page).to have_content(@invoice_1.total_revenue)
+    end
+
+    it "shows a select field to update the invoice status" do
+      visit merchant_invoice_path(@merchant1, @invoice_1)
+
+      within("#the-status-#{@ii_1.id}") do
+        page.select("cancelled")
+        click_button "Update Invoice"
+
+        expect(page).to have_content("cancelled")
+      end
+
+      within("#current-invoice-status") do
+        expect(page).to_not have_content("in progress")
+      end
+    end
+  end
+
+  describe 'Project Part 2' do
+    before :each do
+      @merchant1 = Merchant.create!(name: "Hair Care")
+      @merchant2 = Merchant.create!(name: "Jewelry")
+
+      @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
+      @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
+
+      @item_5 = Item.create!(name: "Bracelet", description: "Wrist bling", unit_price: 200, merchant_id: @merchant2.id)
+      @item_6 = Item.create!(name: "Necklace", description: "Neck bling", unit_price: 300, merchant_id: @merchant2.id)
+
+      @customer_1 = Customer.create!(first_name: "Joey", last_name: "Smith")
+      @customer_2 = Customer.create!(first_name: "Cecilia", last_name: "Jones")
+
+      @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-27 14:54:09")
+      @invoice_2 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-28 14:54:09")
+      @invoice_3 = Invoice.create!(customer_id: @customer_2.id, status: 2)
+
+      @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
+      @ii_2 = InvoiceItem.create!(invoice_id: @invoice_2.id, item_id: @item_1.id, quantity: 1, unit_price: 10, status: 2)
+      @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 12, unit_price: 6, status: 1)
+
+      @transaction1 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_1.id)
+
+      @discount_1 = Discount.create!(percentage: 50, quantity_threshold: 10, merchant_id: @merchant1.id)
+      visit merchant_invoice_path(@merchant1, @invoice_1)
+    end
+
+      # 6: Merchant Invoice Show Page: Total Revenue and Discounted Revenue
+      # As a merchant
+      # When I visit my merchant invoice show page
+      # Then I see the total revenue for my merchant from this invoice (not including discounts)
+      # And I see the total discounted revenue for my merchant from this invoice which includes bulk discounts in the calculation
+    it 'Shows total revenue and discount revenue for invoice' do
+      expect(page).to have_content('Total Revenue: $162.0')
+      expect(page).to have_content('Discount Revenue: $144.0')
     end
   end
 

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe InvoiceItem, type: :model do
   describe "relationships" do
     it { should belong_to :invoice }
     it { should belong_to :item }
+    it { should have_one(:merchant).through(:item) }
   end
 
   describe "class methods" do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Invoice, type: :model do
     it { should have_many(:items).through(:invoice_items) }
     it { should have_many(:merchants).through(:items) }
     it { should have_many :transactions}
-    it { should have_many(:bulk_discounts).through(:items) }
+    # it { should have_many(:bulk_discounts).through(:items) }
 
   end
   describe "instance methods" do
@@ -53,13 +53,29 @@ RSpec.describe Invoice, type: :model do
 
         @transaction1 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_1.id)
 
-        @discount_1a = BulkDiscount.create!(percentage: 50, quantity_threshold: 10, merchant_id: @merchant1.id)
         @discount_2a = BulkDiscount.create!(percentage: 50, quantity_threshold: 1, merchant_id: @merchant2.id)
       end
 
       it 'returns discount revenue after applicable discounts applied, single discount' do
+        @discount_1a = BulkDiscount.create!(percentage: 50, quantity_threshold: 10, merchant_id: @merchant1.id)
+
         expect(@invoice_1.discount_revenue).to eq(140)
       end
+
+      it 'returns discount revenue after applicable discounts applied, more discounts' do
+        @discount_1a = BulkDiscount.create!(percentage: 50, quantity_threshold: 10, merchant_id: @merchant1.id)
+        @discount_1b = BulkDiscount.create!(percentage: 40, quantity_threshold: 5, merchant_id: @merchant1.id)
+
+        expect(@invoice_1.discount_revenue).to eq(104)
+      end
+
+      it 'returns discount revenue after applicable discounts applied, no discounts' do
+        @discount_1a = BulkDiscount.create!(percentage: 50, quantity_threshold: 100, merchant_id: @merchant1.id)
+        @discount_1b = BulkDiscount.create!(percentage: 40, quantity_threshold: 100, merchant_id: @merchant1.id)
+
+        expect(@invoice_1.discount_revenue).to eq(190)
+      end
+
     end
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Invoice, type: :model do
     it { should have_many(:items).through(:invoice_items) }
     it { should have_many(:merchants).through(:items) }
     it { should have_many :transactions}
+    it { should have_many(:bulk_discounts).through(:items) }
+
   end
   describe "instance methods" do
     describe '#total_revenue' do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -12,16 +12,52 @@ RSpec.describe Invoice, type: :model do
     it { should have_many :transactions}
   end
   describe "instance methods" do
-    it "total_revenue" do
-      @merchant1 = Merchant.create!(name: 'Hair Care')
-      @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
-      @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
-      @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
-      @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-27 14:54:09")
-      @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
-      @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 1, unit_price: 10, status: 1)
+    describe '#total_revenue' do
+      it "returns total revenue from all items invoice if sold" do
+        @merchant1 = Merchant.create!(name: 'Hair Care')
+        @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
+        @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
+        @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
+        @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-27 14:54:09")
+        @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
+        @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 1, unit_price: 10, status: 1)
 
-      expect(@invoice_1.total_revenue).to eq(100)
+        expect(@invoice_1.total_revenue).to eq(100)
+      end
+    end
+
+    describe '#discount_revenue' do
+      before(:each) do
+        @merchant1 = Merchant.create!(name: "Hair Care")
+        @merchant2 = Merchant.create!(name: "Jewelry")
+
+        @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
+        @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
+
+        @item_5 = Item.create!(name: "Bracelet", description: "Wrist bling", unit_price: 200, merchant_id: @merchant2.id)
+        @item_6 = Item.create!(name: "Necklace", description: "Neck bling", unit_price: 300, merchant_id: @merchant2.id)
+
+        @customer_1 = Customer.create!(first_name: "Joey", last_name: "Smith")
+        @customer_2 = Customer.create!(first_name: "Cecilia", last_name: "Jones")
+
+        @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-27 14:54:09")
+        @invoice_2 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-28 14:54:09")
+        @invoice_3 = Invoice.create!(customer_id: @customer_2.id, status: 2)
+
+        @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
+        @ii_1a = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 10, unit_price: 10, status: 2)
+
+        @ii_2 = InvoiceItem.create!(invoice_id: @invoice_2.id, item_id: @item_1.id, quantity: 1, unit_price: 10, status: 2)
+
+        @transaction1 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_1.id)
+
+        @discount_1a = Discount.create!(percentage: 50, quantity_threshold: 10, merchant_id: @merchant1.id)
+        @discount_2a = Discount.create!(percentage: 50, quantity_threshold: 1, merchant_id: @merchant2.id)
+      end
+
+      it 'returns discount revenue after applicable discounts applied, single discount' do
+        expect(@invoice_1.discount_revenue).to eq(140)
+      end
     end
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe Invoice, type: :model do
 
         @transaction1 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_1.id)
 
-        @discount_1a = Discount.create!(percentage: 50, quantity_threshold: 10, merchant_id: @merchant1.id)
-        @discount_2a = Discount.create!(percentage: 50, quantity_threshold: 1, merchant_id: @merchant2.id)
+        @discount_1a = BulkDiscount.create!(percentage: 50, quantity_threshold: 10, merchant_id: @merchant1.id)
+        @discount_2a = BulkDiscount.create!(percentage: 50, quantity_threshold: 1, merchant_id: @merchant2.id)
       end
 
       it 'returns discount revenue after applicable discounts applied, single discount' do


### PR DESCRIPTION
6: Merchant Invoice Show Page: Total Revenue and Discounted Revenue
As a merchant
When I visit my merchant invoice show page
Then I see the total revenue for my merchant from this invoice (not including discounts)
And I see the total discounted revenue for my merchant from this invoice which includes bulk discounts in the calculation

Used a little Ruby in the Query, for some reason, `pluck(:item_revenue)` did not work
Figured it out in SQL, but still couldn't get sum of ALL discounts